### PR TITLE
🚀FX-79 feat: 헌혈증 레드박스 기부 기능 구현

### DIFF
--- a/redbox/src/main/java/fx/redbox/controller/api/DonorCardResponseMessage.java
+++ b/redbox/src/main/java/fx/redbox/controller/api/DonorCardResponseMessage.java
@@ -5,7 +5,7 @@ public enum DonorCardResponseMessage {
     DUPLICATE_DONORCARD("이미 등록된 헌혈증", 404),
     READ_DONORCARD("헌혈증 단건 조회 성공", 200),
     READ_ALL_DONORCARD("헌혈증 전체 조회 성공", 200),
-    NOT_FOUND_DONORCARD("헌혈증 조회 실패", 500),
+    NOT_FOUND_DONORCARD("헌혈증 정보를 찾을 수 없습니다.", 404),
 
     INTERNAL_SERVER_ERROR("서버 내부 에러", 500),
     DB_ERROR("데이터베이스 에러", 500);

--- a/redbox/src/main/java/fx/redbox/controller/api/RedboxResponseMessage.java
+++ b/redbox/src/main/java/fx/redbox/controller/api/RedboxResponseMessage.java
@@ -1,0 +1,25 @@
+package fx.redbox.controller.api;
+
+public enum RedboxResponseMessage {
+
+    SUCCESS_REDBOX_GIVE("레드박스 기부 성공", 200);
+
+
+
+
+    private final String message;
+    private final int statusCode;
+
+    RedboxResponseMessage(String message, int statusCode) {
+        this.message = message;
+        this.statusCode = statusCode;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+    }

--- a/redbox/src/main/java/fx/redbox/controller/donorCard/DonorController.java
+++ b/redbox/src/main/java/fx/redbox/controller/donorCard/DonorController.java
@@ -49,7 +49,7 @@ public class DonorController {
             description = "증서번호, 성명, 생년월일, 헌혈일, 혈액원명, 헌혈종류, 성별을 이용해 단일 헌혈증을 조회합니다."
     )
     @ApiResponse(responseCode = "200", description = "단일 헌혈증 조회 성공.")
-    @ApiResponse(responseCode = "404", description = "단일 헌혈증 조회 실패.")
+    @ApiResponse(responseCode = "404", description = "헌혈증 정보를 찾을 수 없습니다.")
     public ResponseApi showDonorCardByCertificateNumber(@PathVariable String certificateNumber) throws SQLException{
         Optional<ReadDonorCardForm> readDonorCardForm = donorCardService.findDonorCard(certificateNumber);
 
@@ -62,7 +62,7 @@ public class DonorController {
             description = "증서번호, 헌혈종류, 헌혈일자, 혈액원명을 이용해 전체 헌혈증을 조회합니다."
     )
     @ApiResponse(responseCode = "200", description = "전체 헌혈증 조회 성공.")
-    @ApiResponse(responseCode = "404", description = "전체 헌혈증 조회 실패.")
+    @ApiResponse(responseCode = "404", description = "헌혈증 정보를 찾을 수 없습니다.")
     public ResponseApi showAllDonorCards(@Login User loginuser) {
         List<ReadAllDonorCardForm> donorCards = donorCardService.findAllDonorCards(loginuser);
 

--- a/redbox/src/main/java/fx/redbox/controller/give/RedboxGiveController.java
+++ b/redbox/src/main/java/fx/redbox/controller/give/RedboxGiveController.java
@@ -1,0 +1,31 @@
+package fx.redbox.controller.give;
+
+import fx.redbox.config.argumentresolver.Login;
+import fx.redbox.controller.api.RedboxResponseMessage;
+import fx.redbox.controller.api.ResponseApi;
+import fx.redbox.entity.users.User;
+import fx.redbox.service.donorCard.DonorCardService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "REDBOX GIVE API", description = "레드박스 기부 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/redbox")
+public class RedboxGiveController {
+
+    private final DonorCardService donorCardService;
+
+    @PostMapping("/{certificateNumber}")
+    @Operation(summary = "레드박스 기부", description = "증서번호를 사용해 레드박스에 기부합니다.")
+    @ApiResponse(responseCode = "200", description = "레드박스 기부 성공")
+    @ApiResponse(responseCode = "404", description = "헌혈증 정보를 찾을 수 없습니다.")
+    public ResponseApi redboxGive(@PathVariable String certificateNumber, @Login User loginUser) {
+        donorCardService.redboxGive(certificateNumber, loginUser);
+        return ResponseApi.success(RedboxResponseMessage.SUCCESS_REDBOX_GIVE.getMessage());
+    }
+
+}

--- a/redbox/src/main/java/fx/redbox/repository/donorCard/DonorCardRepository.java
+++ b/redbox/src/main/java/fx/redbox/repository/donorCard/DonorCardRepository.java
@@ -12,12 +12,12 @@ public interface DonorCardRepository {
 
     boolean existsDonorCardByCertificateNumber(String certificateNumber);
 
-    Optional<DonorCard> findDonorCardByCertificateNumber(String certificateNumber) throws SQLException;
+    Optional<DonorCard> findDonorCardByCertificateNumber(String certificateNumber);
 
     List<DonorCard> findAllDonorCards(Long userId);
 
     List<DonorCard> findAllDonorCards();
 
-    void updateDonorCardUserId(String certificateNumber);
+    void assignRedboxOwnerToDonorCard(String certificateNumber);
 
 }

--- a/redbox/src/main/java/fx/redbox/repository/donorCard/DonorCardRepository.java
+++ b/redbox/src/main/java/fx/redbox/repository/donorCard/DonorCardRepository.java
@@ -18,4 +18,6 @@ public interface DonorCardRepository {
 
     List<DonorCard> findAllDonorCards();
 
+    void updateDonorCardUserId(String certificateNumber);
+
 }

--- a/redbox/src/main/java/fx/redbox/repository/donorCard/DonorCardRepositoryImpl.java
+++ b/redbox/src/main/java/fx/redbox/repository/donorCard/DonorCardRepositoryImpl.java
@@ -72,6 +72,13 @@ public class DonorCardRepositoryImpl implements DonorCardRepository{
         return donorCards;
     }
 
+    @Override
+    public void updateDonorCardUserId(String certificateNumber) {
+        // user_id 1번은 레드박스 소유이다!!!!!
+        String sql = "UPDATE donor_cards SET user_id = 1 WHERE certificate_number = ?";
+        jdbcTemplate.update(sql, certificateNumber);
+    }
+
     private RowMapper<DonorCard> donorCardRowMapper(){
         return((rs, rowNum) -> {
             DonorCard donorCard = DonorCard.builder()

--- a/redbox/src/main/java/fx/redbox/repository/donorCard/DonorCardRepositoryImpl.java
+++ b/redbox/src/main/java/fx/redbox/repository/donorCard/DonorCardRepositoryImpl.java
@@ -73,7 +73,7 @@ public class DonorCardRepositoryImpl implements DonorCardRepository{
     }
 
     @Override
-    public void updateDonorCardUserId(String certificateNumber) {
+    public void assignRedboxOwnerToDonorCard(String certificateNumber) {
         // user_id 1번은 레드박스 소유이다!!!!!
         String sql = "UPDATE donor_cards SET user_id = 1 WHERE certificate_number = ?";
         jdbcTemplate.update(sql, certificateNumber);

--- a/redbox/src/main/java/fx/redbox/service/donorCard/DonorCardService.java
+++ b/redbox/src/main/java/fx/redbox/service/donorCard/DonorCardService.java
@@ -17,4 +17,5 @@ public interface DonorCardService {
 
     List<ReadAllDonorCardForm> findAllDonorCards(User user);
 
+    void redboxGive(String certificateNumber, User user);
 }

--- a/redbox/src/main/java/fx/redbox/service/donorCard/DonorCardServiceImpl.java
+++ b/redbox/src/main/java/fx/redbox/service/donorCard/DonorCardServiceImpl.java
@@ -9,7 +9,6 @@ import fx.redbox.entity.donorCards.DonorCard;
 import fx.redbox.entity.users.User;
 import fx.redbox.repository.donorCard.DonorCardRepository;
 import fx.redbox.repository.user.UserRepository;
-import fx.redbox.service.user.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -70,6 +69,29 @@ public class DonorCardServiceImpl implements DonorCardService{
         return convertToReadAllDonorCardFormList(donorCards);
     }
 
+    @Override //레드박스 기부 시 userId가 1이 지정됨.
+    public void redboxGive(String certificateNumber, User user) {
+
+        //해당 사용자의 헌혈증이 맞는지 검증한다.
+        boolean certificateNumerCheck = false;
+        List<DonorCard> allDonorCards = donorCardRepository.findAllDonorCards(user.getUserId());
+        for(DonorCard donorCard : allDonorCards) {
+            if(donorCard.equals(certificateNumber)) {
+                certificateNumerCheck = true;
+                break;
+            }
+        }
+
+        //파라미터에서 넘어온 헌혈증 번호와 사용자가 가지고 있는 헌혈증이 일치하지 않으면 예외 발생
+        if(!certificateNumerCheck) {
+            throw new DonorCardNotFoundException();
+        }
+
+        donorCardRepository.findDonorCardByCertificateNumber(certificateNumber)
+                .orElseThrow(DonorCardNotFoundException::new);
+
+        donorCardRepository.assignRedboxOwnerToDonorCard(certificateNumber);
+    }
 
     public List<ReadAllDonorCardForm> convertToReadAllDonorCardFormList(List<DonorCard> donorCards) {
         return donorCards.stream().map(donorCard -> {

--- a/redbox/src/main/java/fx/redbox/service/donorCard/DonorCardServiceImpl.java
+++ b/redbox/src/main/java/fx/redbox/service/donorCard/DonorCardServiceImpl.java
@@ -76,7 +76,7 @@ public class DonorCardServiceImpl implements DonorCardService{
         boolean certificateNumerCheck = false;
         List<DonorCard> allDonorCards = donorCardRepository.findAllDonorCards(user.getUserId());
         for(DonorCard donorCard : allDonorCards) {
-            if(donorCard.equals(certificateNumber)) {
+            if(donorCard.getCertificateNumber().equals(certificateNumber)) {
                 certificateNumerCheck = true;
                 break;
             }


### PR DESCRIPTION
# 💫AS IS
헌혈증을 레드박스에 기부 기능을 구현해야 함

# 💫TO BE
`http://localhost:8080/redbox/{certificateNumber}` 헌혈 증서 번호로 레드박스에 기부할 수 있고 기부된 헌혈증의 소유자는 `REDBOX`가 된다. 

`REDBOX`의 `userId=1`이다.