### PR TITLE
🛠️FX-79 fix: [BE] 기부 시 사용자 기부 개수 증가 기능 추가

### DIFF
--- a/redbox/src/main/java/fx/redbox/repository/user/UserRepository.java
+++ b/redbox/src/main/java/fx/redbox/repository/user/UserRepository.java
@@ -27,6 +27,7 @@ public interface UserRepository {
     Optional<User> findEmail(String name, String phone);
     boolean existsByNameAndEmail(String name, String email);
     void insertPassword(String email, String password);
+    void incrementDonationCount(Long userId);
 
 
 }

--- a/redbox/src/main/java/fx/redbox/repository/user/UserRepositoryImpl.java
+++ b/redbox/src/main/java/fx/redbox/repository/user/UserRepositoryImpl.java
@@ -114,12 +114,21 @@ public class UserRepositoryImpl implements UserRepository {
         return cnt > 0;
     }
 
+    @Override
     public void insertPassword(String email, String password) {
         String sql = "UPDATE user_accounts" +
                 " SET password = ?" +
                 " WHERE email = ?";
         jdbcTemplate.update(sql, password, email);
     }
+
+    @Override
+    public void incrementDonationCount(Long userId) {
+        String sql = "UPDATE user_info SET donation_count = donation_count + 1" +
+                " WHERE user_info_id = ?";
+        jdbcTemplate.update(sql, userId);
+    }
+
 
 
 

--- a/redbox/src/main/java/fx/redbox/service/donorCard/DonorCardServiceImpl.java
+++ b/redbox/src/main/java/fx/redbox/service/donorCard/DonorCardServiceImpl.java
@@ -90,8 +90,8 @@ public class DonorCardServiceImpl implements DonorCardService{
 
         return new RedBoxDashboardInfo(totalDonorCards, userDonorCards, contributionRate);
     }
-  
-    @Override //레드박스 기부 시 userId가 1이 지정됨.
+
+    @Override //레드박스 기부 시 userId가 1이 지정됨. & 사용자의 기부개수 1 증가
     public void redboxGive(String certificateNumber, User user) {
 
         //해당 사용자의 헌혈증이 맞는지 검증한다.
@@ -109,8 +109,11 @@ public class DonorCardServiceImpl implements DonorCardService{
             throw new DonorCardNotFoundException();
         }
 
-        donorCardRepository.findDonorCardByCertificateNumber(certificateNumber)
-                .orElseThrow(DonorCardNotFoundException::new);
+//        donorCardRepository.findDonorCardByCertificateNumber(certificateNumber)
+//                .orElseThrow(DonorCardNotFoundException::new);
+
+        //사용자 기부개수 1늘림
+        userRepository.incrementDonationCount(user.getUserId());
 
         donorCardRepository.assignRedboxOwnerToDonorCard(certificateNumber);
     }


### PR DESCRIPTION
# 💫AS IS 
#30 
레드박스 기부 시 사용자의 기부 카운트가 되지 않았음.

# 💫TO BE
`UserRepository`에  user_info 테이블의 donation_count를 늘려주는 메서드 `incrementDonationCount` 를 추가
```
    @Override
    public void incrementDonationCount(Long userId) {
        String sql = "UPDATE user_info SET donation_count = donation_count + 1" +
                " WHERE user_info_id = ?";
        jdbcTemplate.update(sql, userId);
    }
```
`DonorCardService`에서 호출 
```

        //사용자 기부개수 1늘림
        userRepository.incrementDonationCount(user.getUserId()); //추가된 코드

        donorCardRepository.assignRedboxOwnerToDonorCard(certificateNumber);
    }
```