### PR TITLE
🛠️FX-77 fix: [BE] 사용자 donation_count를 select하도록 수정

### DIFF
--- a/redbox/src/main/java/fx/redbox/repository/user/UserRepository.java
+++ b/redbox/src/main/java/fx/redbox/repository/user/UserRepository.java
@@ -28,6 +28,6 @@ public interface UserRepository {
     boolean existsByNameAndEmail(String name, String email);
     void insertPassword(String email, String password);
     void incrementDonationCount(Long userId);
-
+    int findDonationCountByUserId(Long userId);
 
 }

--- a/redbox/src/main/java/fx/redbox/repository/user/UserRepository.java
+++ b/redbox/src/main/java/fx/redbox/repository/user/UserRepository.java
@@ -27,6 +27,7 @@ public interface UserRepository {
     Optional<User> findEmail(String name, String phone);
     boolean existsByNameAndEmail(String name, String email);
     void insertPassword(String email, String password);
+    void incrementDonationCount(Long userId);
 
 
 }

--- a/redbox/src/main/java/fx/redbox/repository/user/UserRepositoryImpl.java
+++ b/redbox/src/main/java/fx/redbox/repository/user/UserRepositoryImpl.java
@@ -114,12 +114,21 @@ public class UserRepositoryImpl implements UserRepository {
         return cnt > 0;
     }
 
+    @Override
     public void insertPassword(String email, String password) {
         String sql = "UPDATE user_accounts" +
                 " SET password = ?" +
                 " WHERE email = ?";
         jdbcTemplate.update(sql, password, email);
     }
+
+    @Override
+    public void incrementDonationCount(Long userId) {
+        String sql = "UPDATE user_info SET donation_count = donation_count + 1" +
+                " WHERE user_info_id = ?";
+        jdbcTemplate.update(sql, userId);
+    }
+
 
 
 

--- a/redbox/src/main/java/fx/redbox/repository/user/UserRepositoryImpl.java
+++ b/redbox/src/main/java/fx/redbox/repository/user/UserRepositoryImpl.java
@@ -129,10 +129,11 @@ public class UserRepositoryImpl implements UserRepository {
         jdbcTemplate.update(sql, userId);
     }
 
-
-
-
-
+    @Override
+    public int findDonationCountByUserId(Long userId) {
+        String sql = "SELECT donation_count FROM user_info WHERE user_info_id = ?";
+        return jdbcTemplate.queryForObject(sql, Integer.class, userId);
+    }
 
     private void saveUserData(UserAccount userAccount, UserInfo userInfo, User user) {
         // user_accounts 테이블

--- a/redbox/src/main/java/fx/redbox/service/donorCard/DonorCardServiceImpl.java
+++ b/redbox/src/main/java/fx/redbox/service/donorCard/DonorCardServiceImpl.java
@@ -90,8 +90,8 @@ public class DonorCardServiceImpl implements DonorCardService{
 
         return new RedBoxDashboardInfo(totalDonorCards, userDonorCards, contributionRate);
     }
-  
-    @Override //레드박스 기부 시 userId가 1이 지정됨.
+
+    @Override //레드박스 기부 시 userId가 1이 지정됨. & 사용자의 기부개수 1 증가
     public void redboxGive(String certificateNumber, User user) {
 
         //해당 사용자의 헌혈증이 맞는지 검증한다.
@@ -109,8 +109,11 @@ public class DonorCardServiceImpl implements DonorCardService{
             throw new DonorCardNotFoundException();
         }
 
-        donorCardRepository.findDonorCardByCertificateNumber(certificateNumber)
-                .orElseThrow(DonorCardNotFoundException::new);
+//        donorCardRepository.findDonorCardByCertificateNumber(certificateNumber)
+//                .orElseThrow(DonorCardNotFoundException::new);
+
+        //사용자 기부개수 1늘림
+        userRepository.incrementDonationCount(user.getUserId());
 
         donorCardRepository.assignRedboxOwnerToDonorCard(certificateNumber);
     }

--- a/redbox/src/main/java/fx/redbox/service/donorCard/DonorCardServiceImpl.java
+++ b/redbox/src/main/java/fx/redbox/service/donorCard/DonorCardServiceImpl.java
@@ -77,8 +77,8 @@ public class DonorCardServiceImpl implements DonorCardService{
         userRepository.findByUserId(user.getUserId()).orElseThrow(UserNotFoundException::new);
 
         // 사용자 ID에 해당하는 헌혈증 수 카운트
-        int totalDonorCards = donorCardRepository.countDonorCardByUserId(1L);
-        int userDonorCards = donorCardRepository.countDonorCardByUserId(user.getUserId());
+        int totalDonorCards = donorCardRepository.countDonorCardByUserId(1L); //1L은 레드박스 소유임! 나중에 상수 처리해야함
+        int userDonorCards = userRepository.findDonationCountByUserId(user.getUserId());
 
         // 기여도 계산
         double contributionRate;


### PR DESCRIPTION
# 💫AS IS
#29 
헌혈증 테이블의 userId로 사용자 기부 개수를 카운트함 -> 레드박스 기부 시 소유자가 변경돼 기부 수가 누적되지 않음

 # 💫TO BE
user_info 테이블의 donation_count를 사용해 기부 개수를 셈