### PR TITLE
🪛FX-81 refactor: [BE] 헌혈증 저장 시 사용자의 혈액형도 자동 등록

### DIFF
--- a/redbox/src/main/java/fx/redbox/controller/donorCard/DonorController.java
+++ b/redbox/src/main/java/fx/redbox/controller/donorCard/DonorController.java
@@ -39,7 +39,7 @@ public class DonorController {
 
         donorCardData.setUserId(loginUser.getUserId());
 
-        donorCardService.saveDonorCard(donorCardData);
+        donorCardService.saveDonorCard(donorCardData, loginUser);
 
         return ResponseApi.success(DonorCardResponseMessage.CREATED_DONORCARD.getMessage());
     }

--- a/redbox/src/main/java/fx/redbox/controller/donorCard/DonorController.java
+++ b/redbox/src/main/java/fx/redbox/controller/donorCard/DonorController.java
@@ -35,7 +35,7 @@ public class DonorController {
     )
     @ApiResponse(responseCode = "200", description = "헌혈증 저장 성공.")
     @ApiResponse(responseCode = "404", description = "헌혈증 저장 실패.")
-    public ResponseApi saveDonorCard(@RequestBody DonorCard donorCardData, @Login User loginUser) throws SQLException {
+    public ResponseApi saveDonorCard(@RequestBody DonorCard donorCardData, @Login User loginUser) {
 
         donorCardData.setUserId(loginUser.getUserId());
 

--- a/redbox/src/main/java/fx/redbox/entity/donorCards/DonorCard.java
+++ b/redbox/src/main/java/fx/redbox/entity/donorCards/DonorCard.java
@@ -1,5 +1,6 @@
 package fx.redbox.entity.donorCards;
 
+import fx.redbox.entity.enums.BloodType;
 import fx.redbox.entity.enums.DonorBloodKind;
 import fx.redbox.entity.enums.Gender;
 import lombok.Builder;
@@ -22,5 +23,5 @@ public class DonorCard {
     private Gender donorGender;
     private String bloodCenter;
     private Long userId;
-
+    private BloodType bloodType;
 }

--- a/redbox/src/main/java/fx/redbox/repository/donorCard/DonorCardRepository.java
+++ b/redbox/src/main/java/fx/redbox/repository/donorCard/DonorCardRepository.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 
 public interface DonorCardRepository {
 
-    Optional<DonorCard> saveDonorCard(DonorCard donorCard) throws SQLException;
+    Optional<DonorCard> saveDonorCard(DonorCard donorCard);
 
     boolean existsDonorCardByCertificateNumber(String certificateNumber);
 

--- a/redbox/src/main/java/fx/redbox/repository/donorCard/DonorCardRepositoryImpl.java
+++ b/redbox/src/main/java/fx/redbox/repository/donorCard/DonorCardRepositoryImpl.java
@@ -33,7 +33,7 @@ public class DonorCardRepositoryImpl implements DonorCardRepository{
         donorCardParam.put("donor_gender", donorCard.getDonorGender().name()); //enum 을 string 형으로
         donorCardParam.put("blood_center",donorCard.getBloodCenter());
         donorCardParam.put("user_id",donorCard.getUserId());
-
+        donorCardParam.put("blood_type",donorCard.getBloodType().name());
         donorCardJdbcInsert.execute(donorCardParam);
 
         return Optional.of(donorCard);

--- a/redbox/src/main/java/fx/redbox/service/donorCard/DonorCardService.java
+++ b/redbox/src/main/java/fx/redbox/service/donorCard/DonorCardService.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 
 public interface DonorCardService {
 
-    Optional<DonorCard> saveDonorCard(DonorCard donorCard) throws SQLException;
+    Optional<DonorCard> saveDonorCard(DonorCard donorCard, User user);
 
     Optional<ReadDonorCardForm> findDonorCard(String certificateNumber) throws SQLException;
 

--- a/redbox/src/main/java/fx/redbox/service/donorCard/DonorCardServiceImpl.java
+++ b/redbox/src/main/java/fx/redbox/service/donorCard/DonorCardServiceImpl.java
@@ -7,6 +7,7 @@ import fx.redbox.controller.donorCard.form.ReadAllDonorCardForm;
 import fx.redbox.controller.donorCard.form.ReadDonorCardForm;
 import fx.redbox.controller.donorCard.form.RedBoxDashboardInfo;
 import fx.redbox.entity.donorCards.DonorCard;
+import fx.redbox.entity.enums.BloodType;
 import fx.redbox.entity.users.User;
 import fx.redbox.repository.donorCard.DonorCardRepository;
 import fx.redbox.repository.user.UserRepository;
@@ -28,12 +29,17 @@ public class DonorCardServiceImpl implements DonorCardService{
     private final UserRepository userRepository;
 
     @Override
-    public Optional<DonorCard> saveDonorCard(DonorCard donorCard) throws SQLException {
+    public Optional<DonorCard> saveDonorCard(DonorCard donorCard, User user) {
 
         // 헌혈증 중복 검증
         boolean exits = donorCardRepository.existsDonorCardByCertificateNumber(donorCard.getCertificateNumber());
         if(exits)
             throw new DuplicateCertificateNumberException();
+
+        //사용자의 혈액형 파악
+        User userInfo = userRepository.findByUserId(user.getUserId()).orElseThrow(UserNotFoundException::new);
+        BloodType bloodType = userInfo.getBloodType();
+        donorCard.setBloodType(bloodType);
 
         // 정보에 빈문자열일 때 예외처리 -> ?
         Optional<DonorCard> savedDonorCard = donorCardRepository.saveDonorCard(donorCard);


### PR DESCRIPTION
# 💫AS IS 

헌혈증 저장 시 사용자의 혈액형은 저장되지 않음

→ 레드박스로 기부될 때 이 헌혈증이 어느 혈액형을 가지고 있는지 파악 불가

# 💫TO BE

donor_cards 테이블에 blood_type 컬럼을 추가

헌혈증을 저장할 때 사용자의 혈액형을 가져와 혈액형을 저장할 때 bloodType을 추가함