### PR TITLE
🚀FX-84 feat: [BE] 요청 승인시 레드박스 헌혈증을 요청자에게 소유권 변경

### DIFF
--- a/redbox/src/main/java/fx/redbox/common/DonorCardRequestExceptionAdvice.java
+++ b/redbox/src/main/java/fx/redbox/common/DonorCardRequestExceptionAdvice.java
@@ -1,5 +1,6 @@
 package fx.redbox.common;
 
+import fx.redbox.common.Exception.DonorCardRequestExhaustedException;
 import fx.redbox.common.Exception.DonorCardRequestNotFoundException;
 import fx.redbox.common.Exception.DuplicateDonorCardRequestException;
 import fx.redbox.controller.api.DonorCardRequestResponseMessage;
@@ -27,5 +28,13 @@ public class DonorCardRequestExceptionAdvice {
         log.error("헌혈증 요청 자료를 찾을 수 없습니다.");
         return ResponseApi.fail(DonorCardRequestResponseMessage.DONOR_CARD_REQUEST_NOT_FOUND.getStatusCode(),
                 DonorCardRequestResponseMessage.DONOR_CARD_REQUEST_NOT_FOUND.getMessage());
+    }
+
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ExceptionHandler(DonorCardRequestExhaustedException.class)
+    public ResponseApi donorCardRequestExhausted() {
+        log.error("레드박스 헌혈증이 없습니다.");
+        return ResponseApi.fail(DonorCardRequestResponseMessage.DONOR_CARD_REQUEST_EXHAUSTED.getStatusCode(),
+                DonorCardRequestResponseMessage.DONOR_CARD_REQUEST_EXHAUSTED.getMessage());
     }
 }

--- a/redbox/src/main/java/fx/redbox/common/Exception/DonorCardRequestExhaustedException.java
+++ b/redbox/src/main/java/fx/redbox/common/Exception/DonorCardRequestExhaustedException.java
@@ -1,0 +1,22 @@
+package fx.redbox.common.Exception;
+
+public class DonorCardRequestExhaustedException extends RuntimeException {
+    public DonorCardRequestExhaustedException() {
+    }
+
+    public DonorCardRequestExhaustedException(String message) {
+        super(message);
+    }
+
+    public DonorCardRequestExhaustedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public DonorCardRequestExhaustedException(Throwable cause) {
+        super(cause);
+    }
+
+    public DonorCardRequestExhaustedException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/redbox/src/main/java/fx/redbox/controller/api/DonorCardRequestResponseMessage.java
+++ b/redbox/src/main/java/fx/redbox/controller/api/DonorCardRequestResponseMessage.java
@@ -7,7 +7,8 @@ public enum DonorCardRequestResponseMessage {
     DONOR_CARD_REQUEST_UPDATE_SUCCESS("헌혈증 요청 심사 업데이트 성공", 200),
 
     DONOR_CARD_REQUEST_DUPLICATE("이미 등록된 요청", 400),
-    DONOR_CARD_REQUEST_NOT_FOUND("헌혈증 요청 자료 없음", 404);
+    DONOR_CARD_REQUEST_NOT_FOUND("헌혈증 요청 자료 없음", 404),
+    DONOR_CARD_REQUEST_EXHAUSTED("레드박스 헌혈증이 없습니다.", 404);
 
     private final String message;
     private final int statusCode;

--- a/redbox/src/main/java/fx/redbox/repository/donorCard/DonorCardRepository.java
+++ b/redbox/src/main/java/fx/redbox/repository/donorCard/DonorCardRepository.java
@@ -22,5 +22,5 @@ public interface DonorCardRepository {
 
     int countDonorCardByUserId(Long userId);
   
-    void assignRedboxOwnerToDonorCard(String certificateNumber);
+    void assignOwnerToDonorCard(String certificateNumber, Long userId);
 }

--- a/redbox/src/main/java/fx/redbox/repository/donorCard/DonorCardRepositoryImpl.java
+++ b/redbox/src/main/java/fx/redbox/repository/donorCard/DonorCardRepositoryImpl.java
@@ -85,10 +85,10 @@ public class DonorCardRepositoryImpl implements DonorCardRepository{
     }
   
     @Override
-    public void assignRedboxOwnerToDonorCard(String certificateNumber) {
+    public void assignOwnerToDonorCard(String certificateNumber, Long userId) {
         // user_id 1번은 레드박스 소유이다!!!!!
-        String sql = "UPDATE donor_cards SET user_id = 1 WHERE certificate_number = ?";
-        jdbcTemplate.update(sql, certificateNumber);
+        String sql = "UPDATE donor_cards SET user_id = ? WHERE certificate_number = ?";
+        jdbcTemplate.update(sql, userId, certificateNumber);
     }
   
     public RowMapper<DonorCard> donorCardRowMapper(){

--- a/redbox/src/main/java/fx/redbox/service/donorCard/DonorCardServiceImpl.java
+++ b/redbox/src/main/java/fx/redbox/service/donorCard/DonorCardServiceImpl.java
@@ -122,7 +122,8 @@ public class DonorCardServiceImpl implements DonorCardService{
         //사용자 기부개수 1늘림
         userRepository.incrementDonationCount(user.getUserId());
 
-        donorCardRepository.assignRedboxOwnerToDonorCard(certificateNumber);
+        //1L = 레드박스 나중에 상수처리하자
+        donorCardRepository.assignOwnerToDonorCard(certificateNumber, 1L);
     }
 
     @Override


### PR DESCRIPTION
# 💫AS IS 

요청 승인시 헌혈증 소유권에 대한 기능 구현이 되어 있지 않음

# 💫TO BE

요청 승인시 헌혈증 소유권이 요청자에게 전달됨

승인 → REDBOX 소유의 헌혈증(userId=1) → 요청자 userId로 변경

레드박스 소유의 헌혈증이 없으면 예외 발생
```
//헌혈증의 소유권을 요청자에게 이전
donorCardRepository.assignOwnerToDonorCard(donorCard.getCertificateNumber(), userId);
```